### PR TITLE
Fix alpha calculation of PNG background

### DIFF
--- a/src/subtitles/STS.cpp
+++ b/src/subtitles/STS.cpp
@@ -3777,8 +3777,9 @@ DWORD MOD_GRADIENT::getmixcolor(int tx, int ty, int i) // too slow T.T
             a = (b_images[i].bpp == 4) ? (((dst21[3] * (8 - subpixx) + dst22[3] * subpixx) >> 3) * (subpixy) + ((a * (8 - subpixx) + dst12[3] * subpixx) >> 3) * (8 - subpixy)) >> 3 : 0xFF;
         }
         // alpha fix
-        DWORD al = (a * b_images[i].alpha * (0xff - fadalpha));
-        colorb = (al & 0xFF0000) << 8 | r << 16 | g << 8 | b;
+#define div_255_fast(x) (((x) + 1 + (((x) + 1) >> 8)) >> 8)
+        BYTE al = div_255_fast(div_255_fast(a * b_images[i].alpha) * (0xff - fadalpha));
+        colorb = al << 24 | r << 16 | g << 8 | b;
 
         return colorb;
     }


### PR DESCRIPTION
Original alpha blending algorithm has poor accuracy and often causes slight color difference when use png background.

For example, blended opacity al=0xFF\*0xFF\*0xFF=0xFD02FF. After the AND operation, opacity value is 0xFD, which obviously should be 0xFF.

Here is a not so elegant patch but it works.