### PR TITLE
Fix #12: movevc tag's funny behavior

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v2

--- a/src/subtitles/RTS.cpp
+++ b/src/subtitles/RTS.cpp
@@ -3756,6 +3756,7 @@ STDMETHODIMP CRenderedTextSubtitle::Render(SubPicDesc& spd, REFERENCE_TIME rt, d
                 }
                 else mod_vc.pos = vcpos2;
                 mod_vc.enable = true;
+                mod_vc.isInverse = s->m_pClipper ? s->m_pClipper->m_inverse : false;
             }
 #endif
             break;

--- a/src/subtitles/Rasterizer.cpp
+++ b/src/subtitles/Rasterizer.cpp
@@ -2162,6 +2162,7 @@ void MOD_MOVEVC::clear()
     curpos = CPoint(0, 0);
     hfull = 0;
     alphamask = NULL;
+    isInverse = false;
 }
 
 byte MOD_MOVEVC::GetAlphaValue(int wx, int wy)
@@ -2178,9 +2179,9 @@ byte MOD_MOVEVC::GetAlphaValue(int wx, int wy)
 
     //check if the point is in canvas, in case of crash
     if (xInCanvas < 0 || xInCanvas >= spd.cx)
-        alpham = 0;
+        alpham = isInverse ? 0x40 : 0; // assume content outside canvas is visible when using iclip. mask is 6 bit
     else if (yInCanvas < 0 || yInCanvas >= spd.cy)
-        alpham = 0;
+        alpham = isInverse ? 0x40 : 0;
     else
     {
         if ((wx - pos.x) < -curpos.x + 1) alpham = 0;

--- a/src/subtitles/Rasterizer.h
+++ b/src/subtitles/Rasterizer.h
@@ -41,6 +41,7 @@ public:
     CPoint curpos;  // output origin point
     int hfull;		// full height
     byte* alphamask;
+    bool isInverse;
 
     MOD_MOVEVC();
 


### PR DESCRIPTION
When a vector drawing mask is moving, canvas on which the mask are drawn also moves. Content that is outside canvas is not masked and thus invisible. This only works for moving \clip tags, however when using \iclip tags should make off canvas part visible.

Sample ass file can be found in Masaiki/VSFilterMod#5